### PR TITLE
Fix: sprite event rows were misconfigured

### DIFF
--- a/modifications/editorPatches/DuplicateDecorationButton.cs
+++ b/modifications/editorPatches/DuplicateDecorationButton.cs
@@ -69,28 +69,41 @@ public class DuplicateDecorationButton : Modification
                 
                 editor.spritesData.Insert(newSpriteDataIndex, newSpriteData);
                 editor.eventControls_sprites.Insert(newSpriteDataIndex, newSpriteEventControls);
-                
-                foreach (LevelEventControl_Base spriteEventControl in spriteEventControls)
+
+				// Move already existing events to the next index,
+				// since LevelEventController_Base.controller indexes based on the event's row
+				foreach (LevelEventControl_Base spriteEventControl in editor.eventControls)
+				{
+					if (spriteEventControl.levelEvent.isSpriteTabEvent)
+					// && (spriteEventControl.levelEvent.type != LevelEventType.Comment || (spriteEventControl.levelEvent as LevelEvent_Comment).tab == Tab.Sprites))
+					{
+						if (spriteEventControl.levelEvent.row >= newSpriteDataIndex)
+						{
+							spriteEventControl.levelEvent.row++;
+						}
+					}
+				}
+
+				foreach (LevelEventControl_Base spriteEventControl in spriteEventControls)
                 {
                     if (spriteEventControl.levelEvent.target == spriteData.spriteId)
                     {
                         LevelEvent_Base newSpriteEvent = spriteEventControl.levelEvent.Clone();
                         newSpriteEvent.target = newSpriteData.spriteId;
                         newSpriteEvent.y++;
-                        newSpriteEvent.row = newSpriteDataIndex;
-                        editor.CreateEventControl(newSpriteEvent, Tab.Sprites, true);
-                        // LevelEventControl_Sprite newSpriteEventControl = (LevelEventControl_Sprite)editor.CreateEventControl(newSpriteEvent, Tab.Sprites, true);
-                    }
+
+						newSpriteEvent.row = newSpriteDataIndex;
+						editor.CreateEventControl(newSpriteEvent, Tab.Sprites, true);
+						// LevelEventControl_Sprite newSpriteEventControl = (LevelEventControl_Sprite)editor.CreateEventControl(newSpriteEvent, Tab.Sprites, true);
+					}
                 }
                 
-                int index = 0;
                 int[] indexRooms = [0, 0, 0, 0];
                 foreach (LevelEventControl_Base spriteEventControl in editor.eventControls)
                 {
                     if (spriteEventControl.levelEvent.isSpriteTabEvent) 
                     // && (spriteEventControl.levelEvent.type != LevelEventType.Comment || (spriteEventControl.levelEvent as LevelEvent_Comment).tab == Tab.Sprites))
                     {
-                        spriteEventControl.levelEvent.row = index++;
                         spriteEventControl.levelEvent.y = indexRooms[SpriteHeader.GetSpriteData(spriteEventControl.levelEvent.target).room]++;
                         spriteEventControl.UpdateUI();
                     }


### PR DESCRIPTION
Sprite events use their "row" field for optimisation, to be able to cull events outside of view. While the events of the duplicate were set correctly, the events of sprites whose indices were higher didn't have their "row" properly set, and as such:

- When deleted, the evnet control removes itself from its "container" (indexes into the sprite event list of lists using its "row")
- As the control was not part of this list, but of the _next_ one, it couldn't remove it
- The event is destroyed, leaving a null reference in the list
- Optimisations kick in and try to hide an event which does not exist, leading to:

`[Error  : Unity Log] NullReferenceException
Stack trace:
UnityEngine.Transform.get_localPosition () (at <c39a522eee05469b8171a6cfeb646c59>:0)
RDLevelEditor.Timeline.CullMaskedObjects () (at <909dbb89220d46b7aa2c20fdc968b1a9>:0)
(wrapper dynamic-method) RDLevelEditor.Timeline.DMD<RDLevelEditor.Timeline::LateUpdate>(RDLevelEditor.Timeline)`

This pull request adds another iteration to the duplication, but it fixes the row of the events and removes the now-unused `index` variable.