### PR TITLE
Support Beta v1.0.4

### DIFF
--- a/RDModifications.csproj
+++ b/RDModifications.csproj
@@ -55,6 +55,9 @@
         <!-- <Reference Include="DOTweenPro" IncludeAssets="compile">
         <HintPath>lib\DOTweenPro.dll</HintPath>
     </Reference> -->
+        <Reference Include="UnityFileDialog" IncludeAssets="compile">
+            <HintPath>lib\UnityFileDialog.dll</HintPath>
+        </Reference>
         <Reference Include="Unity.TextMeshPro" IncludeAssets="compile">
             <HintPath>lib\Unity.TextMeshPro.dll</HintPath>
         </Reference>

--- a/lib/note.txt
+++ b/lib/note.txt
@@ -7,5 +7,6 @@ Assembly-CSharp.dll
 Assembly-CSharp-firstpass.dll
 RDTools.dll
 DOTween.dll
+UnityFileDialog.dll
 Unity.TextMeshPro.dll
 from Rhythm Doctor_Data\Managed

--- a/modifications/editorPatches/ImportAnimatedImages.cs
+++ b/modifications/editorPatches/ImportAnimatedImages.cs
@@ -3,7 +3,7 @@ using System.IO;
 using GIF;
 using HarmonyLib;
 using RDLevelEditor;
-using SFB;
+using UnityFileDialog;
 using Unity.Collections;
 using UnityEngine;
 
@@ -59,7 +59,7 @@ public class ImportAnimatedImages : Modification
 	private class SkipOverwritePatch
     {
 		[HarmonyPostfix]
-		[HarmonyPatch(typeof(StandaloneFileBrowser), nameof(StandaloneFileBrowser.OpenFilePanel), [typeof(string), typeof(string), typeof(ExtensionFilter[]), typeof(bool)])]
+		[HarmonyPatch(typeof(FileBrowser), nameof(FileBrowser.PickFiles), [typeof(string), typeof(string), typeof(string[]), typeof(string)])]
 		public static void OpenFilePanelPostfix(ref string[] __result)
         {
 			if (!ImagesSelectorOpen)


### PR DESCRIPTION
UnityStandaloneFileBrowser was removed and replaced with UnityFileDialog, causing an exception on startup.

Note: I fixed the compilation error and the game loads without any exceptions, but importing APNGs only imports the first frame and importing a .gif leads to `[?]` being shown
Both were imported under the Decorations tab, I'm unsure if I imported incorrectly or if the patch is faulty, please check before merging